### PR TITLE
Fix MPL implementation of BFS path search

### DIFF
--- a/boost_mpl_graph_shortest_path.hpp
+++ b/boost_mpl_graph_shortest_path.hpp
@@ -89,30 +89,27 @@ struct route_finder_visitor : mpl_graph::bfs_default_visitor_operations {
     using dst_t = typename mpl_graph::target<Edge, Graph>::type;
 
     template<typename Edge, typename Graph, typename ParentMap>
-    struct insert_parent_t {
-        using type = typename mpl::insert<ParentMap, mpl::pair<dst_t<Edge, Graph>, src_t<Edge, Graph>>>::type;
-    };
+    struct insert_parent_t : mpl::insert<
+        ParentMap, 
+        mpl::pair<dst_t<Edge, Graph>, src_t<Edge, Graph>>
+    >::type {};
 
     // tree edge (i.e an edge that connects to a vertex we didn't discover yet)
     // it means that this edge's source vertex is the fastest way to get to it's destination vertex
     // mark it as it's parent.
-    // template<typename Edge, typename Graph, typename State>
-    // struct tree_edge : mpl::if_<
-    //     typename State::item3,
-    //     // if already found - do nothing
-    //     State,
-    //     // else - update parent map
-    //     mpl::vector4<
-    //         typename State::item0, // route isn't changed here
-    //         typename mpl::insert<  // update parent map
-    //             typename State::item1, 
-    //             typename mpl_graph::target<Edge, Graph>::type, 
-    //             typename mpl_graph::source<Edge, Graph>::type
-    //         >::type,
-    //         typename State::item2, // target node unchanged
-    //         typename State::item3  // found flag unchanged
-    //     >
-    // > {};
+    template<typename Edge, typename Graph, typename State>
+    struct tree_edge : mpl::if_<
+        typename mpl::at_c<State, 3>::type,
+        // if already found - do nothing
+        State,
+        // else - update parent map
+        mpl::vector4<
+            typename mpl::at_c<State, 0>::type, // route isn't changed here
+            typename insert_parent_t<Edge, Graph, typename mpl::at_c<State,1>::type>::type, // update parent map
+            typename mpl::at_c<State, 2>::type, // target node unchanged
+            typename mpl::at_c<State, 3>::type  // found flag unchanged
+        >
+    > {};
 
     // first time we encounter a new vertex
     // if it's the target vertex - it means we found the fastest route to it

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -18,23 +18,14 @@
 
 
 // vertices
-// struct A{}; 
-// struct B{}; 
-// struct C{}; 
-// struct D{}; 
-// struct E{}; 
-// struct F{}; 
-// struct G{};
-// struct H{};
-#define VERTEX(name) struct name { using type = name; }
-VERTEX(A);
-VERTEX(B);
-VERTEX(C);
-VERTEX(D);
-VERTEX(E);
-VERTEX(F);
-VERTEX(G);
-VERTEX(H);
+struct A{};
+struct B{};
+struct C{};
+struct D{};
+struct E{};
+struct F{};
+struct G{};
+struct H{};
 
 // edges
 struct A_B{};
@@ -153,4 +144,22 @@ TEST(BFSRouteFinderTest, TestRoute1) {
 
     static constexpr auto route_length = bfs_route_length_v<query_result_t>;
     static_assert(route_length == 4);
+}
+
+TEST(BFSRouteFinderTest, Test2) {
+    using graph_2_edges_t = mpl::vector<
+        EDGE(A,B),
+        EDGE(B,D),
+        EDGE(D,F),
+        EDGE(F,H),
+        EDGE(A,C),
+        EDGE(C,E),
+        EDGE(E,G)
+    >;
+    using graph_2_t = mpl_graph::incidence_list_graph<graph_2_edges_t>;
+
+    using route_A_to_H = bfs_route_query_result_t<graph_2_t, A, H>;
+    static_assert(bfs_route_found_v<route_A_to_H>);
+    using route = bfs_route_path_t<route_A_to_H>;
+    static_assert(mpl::equal<route, mpl::vector<A,B,D,F,H>>::value);
 }

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -93,6 +93,21 @@ TEST(BFSRouteFinderTest, MplMapParentMapping) {
     static_assert(boost::is_same<mpl::at<overridden_parent_map_t, B>::type, D>::value, "parent map test failed");
 }
 
+// test mpl_graph::target and mpl_graph::source
+TEST(BFSRouteFinderTest, MplGraphSourceTarget) {
+    using graph_edges_t = mpl::vector<
+       mpl::vector<A_B, A, B>,
+       mpl::vector<B_D, B, D>,
+       mpl::vector<D_F, D, F>
+    >;
+    using graph_t = mpl_graph::incidence_list_graph<graph_edges_t>;
+
+    using edge_AB_source = typename mpl_graph::source<A_B, graph_t>::type;
+    using edge_AB_target = typename mpl_graph::target<A_B, graph_t>::type;
+    static_assert(boost::is_same<edge_AB_source, A>::value, "mpl_graph source test failed");
+    static_assert(boost::is_same<edge_AB_target, B>::value, "mpl_graph target test failed");
+}
+
 // // no route from A to G
 // TEST(BFSRouteFinderTest, NoRouteFromAToG) {
 //     using route_A_to_G = bfs_route_query_result_t<my_graph_type, A, G>;
@@ -100,20 +115,19 @@ TEST(BFSRouteFinderTest, MplMapParentMapping) {
 //     static_assert(!bfs_route_found_v<route_A_to_G>);
 // }
 
-// TEST(BFSRouteFinderTest, Test2) {
-//     using graph_2_edges_t = mpl::vector<
+// TEST(BFSRouteFinderTest, TestRouteFromAtoH) {
+//     using graph_edges_t = mpl::vector<
 //         EDGE(A,B),
 //         EDGE(B,D),
-//         EDGE(D,F),
-//         EDGE(F,H),
-//         EDGE(A,C),
-//         EDGE(C,E),
-//         EDGE(E,G)
+//         EDGE(D,F)
 //     >;
-//     using graph_2_t = mpl_graph::incidence_list_graph<graph_2_edges_t>;
+//     using graph_t = mpl_graph::incidence_list_graph<graph_edges_t>;
 
-//     using route_A_to_H = bfs_route_query_result_t<graph_2_t, A, H>;
-//     static_assert(bfs_route_found_v<route_A_to_H>);
-//     using route = bfs_route_path_t<route_A_to_H>;
-//     static_assert(mpl::equal<route, mpl::vector<A,B,D,F,H>>::value);
+//     using query_result_t = bfs_route_query_result_t<graph_t, A, F>;
+    
+//     using mapping = bfs_parent_map_t<query_result_t>;
+//     static_assert(boost::is_same<typename mpl::at<mapping, A>::type, mpl::void_>::value);
+//     static_assert(boost::is_same<typename mpl::at<mapping, B>::type, A>::value);
+//     static_assert(boost::is_same<typename mpl::at<mapping, D>::type, B>::value);
+//     static_assert(boost::is_same<typename mpl::at<mapping, F>::type, D>::value);
 // }

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -137,7 +137,7 @@ TEST(BFSRouteFinderTest, NoRouteFromAToG) {
     // static_assert(!bfs_route_found_v<route_A_to_G>);
 }
 
-TEST(BFSRouteFinderTest, TestRouteFromAtoH) {
+TEST(BFSRouteFinderTest, TestRoute1) {
     using graph_edges_t = mpl::vector<
         EDGE(A,B),
         EDGE(B,D),
@@ -147,10 +147,10 @@ TEST(BFSRouteFinderTest, TestRouteFromAtoH) {
     using query_result_t = bfs_route_query_result_t<graph_t, A, F>;
 
     static_assert(bfs_route_found_v<query_result_t>, "Route from A to F should be found");
-    
-    // using mapping = bfs_parent_map_t<query_result_t>;
-    // static_assert(boost::is_same<typename mpl::at<mapping, A>::type, mpl::void_>::value);
-    // static_assert(boost::is_same<typename mpl::at<mapping, B>::type, A>::value);
-    // static_assert(boost::is_same<typename mpl::at<mapping, D>::type, B>::value);
-    // static_assert(boost::is_same<typename mpl::at<mapping, F>::type, D>::value);
+
+    using route_t = bfs_route_path_t<query_result_t>;
+    static_assert(mpl::equal<route_t, mpl::vector4<A, B, D, F>>::value, "Route from A to F should be A -> B -> D -> F");
+
+    static constexpr auto route_length = bfs_route_length_v<query_result_t>;
+    static_assert(route_length == 4);
 }

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -15,6 +15,8 @@
 //          \-----/
 // G (disconnected)
 
+
+
 // vertices
 struct A{}; 
 struct B{}; 
@@ -51,9 +53,85 @@ typedef mpl_graph::incidence_list_graph<my_graph_data_type> my_graph_type;
 
 #define EDGE(src,dst) mpl::vector<src##_##dst, src, dst>
 
-// Test that a route exists from A to F and is the shortest path A -> B -> F
+TEST(BFSRouteFinderTest, BacktrackingMetaFunction) {
+    // simple testcase for backtrack
+    struct V1{};
+    struct V2{};
+    struct V3{};
+    using parent_map_example = mpl::map<
+        mpl::pair<V3, V2>,
+        mpl::pair<V2, V1>
+    >;
+    // check that if vertex not in map, we get mpl::void_
+    static_assert(boost::is_same<mpl::at<parent_map_example, V1>::type, mpl::void_>::value, "parent map test failed");
+
+    using backtrack_test_no_parent = typename backtrack<V1, parent_map_example>::type;
+    static_assert(mpl::equal<backtrack_test_no_parent, mpl::vector1<V1>>::value, "backtrack test failed");
+
+    using backtrack_test_1_step = typename backtrack<V2, parent_map_example>::type;
+    static_assert(mpl::equal<backtrack_test_1_step, mpl::vector2<V1, V2>>::value, "backtrack test failed");
+
+    using backtrack_test = typename backtrack<V3, parent_map_example>::type;
+    static_assert(mpl::equal<backtrack_test, mpl::vector3<V1, V2, V3>>::value, "backtrack test failed");
+}
+
+
+template <typename Map1, typename Map2>
+struct map_subset_of
+  : mpl::fold<
+        Map1,
+        mpl::true_,
+        mpl::and_<
+            _1,
+            mpl::and_<
+                mpl::has_key<Map2, typename _2::first>,
+                boost::is_same<
+                    typename mpl::at<Map2, typename _2::first>::type,
+                    typename _2::second
+                >
+            >
+        >
+    >
+{};
+
+// Equality check = subset both ways
+template <typename Map1, typename Map2>
+struct map_equal
+  : mpl::and_<
+        map_subset_of<Map1, Map2>,
+        map_subset_of<Map2, Map1>
+    >
+{};
+
+// small test for compare key-value maps
+using map1 = mpl::map<mpl::pair<A, B>, mpl::pair<C, D>>;
+using map2 = mpl::map<mpl::pair<C, D>, mpl::pair<A, B>>;
+using map3 = mpl::map<mpl::pair<A, B>, mpl::pair<C, D>>;
+static_assert(map_equal<map1, map2>::value, "map equal test failed");
+
+
+// // Test that a route exists from A to F and is the shortest path A -> B -> F
 TEST(BFSRouteFinderTest, RouteFromAToFExists) {
     using route_A_to_F = bfs_route_query_result_t<my_graph_type, A, F>;
+
+    /*
+    parents:
+    B <- A
+    F <- B
+    C <- B
+    D <- C
+    E <- C
+    F <- C
+    */
+    using ref_parent_map = mpl::map<
+        mpl::pair<B, A>,
+        mpl::pair<F, B>,
+        mpl::pair<C, B>,
+        mpl::pair<D, C>,
+        mpl::pair<E, C>,
+        mpl::pair<F, C>>;
+    
+    static_assert(mpl::equal<bfs_parent_map_t<route_A_to_F>, ref_parent_map>::value);
     
     // Check that route was found
     static_assert(bfs_route_found_v<route_A_to_F>);
@@ -67,27 +145,27 @@ TEST(BFSRouteFinderTest, RouteFromAToFExists) {
     static_assert(path_correct);
 }
 
-// no route from A to G
-TEST(BFSRouteFinderTest, NoRouteFromAToG) {
-    using route_A_to_G = bfs_route_query_result_t<my_graph_type, A, G>;
-    // Check that route was not found
-    static_assert(!bfs_route_found_v<route_A_to_G>);
-}
+// // no route from A to G
+// TEST(BFSRouteFinderTest, NoRouteFromAToG) {
+//     using route_A_to_G = bfs_route_query_result_t<my_graph_type, A, G>;
+//     // Check that route was not found
+//     static_assert(!bfs_route_found_v<route_A_to_G>);
+// }
 
-TEST(BFSRouteFinderTest, Test2) {
-    using graph_2_edges_t = mpl::vector<
-        EDGE(A,B),
-        EDGE(B,D),
-        EDGE(D,F),
-        EDGE(F,H),
-        EDGE(A,C),
-        EDGE(C,E),
-        EDGE(E,G)
-    >;
-    using graph_2_t = mpl_graph::incidence_list_graph<graph_2_edges_t>;
+// TEST(BFSRouteFinderTest, Test2) {
+//     using graph_2_edges_t = mpl::vector<
+//         EDGE(A,B),
+//         EDGE(B,D),
+//         EDGE(D,F),
+//         EDGE(F,H),
+//         EDGE(A,C),
+//         EDGE(C,E),
+//         EDGE(E,G)
+//     >;
+//     using graph_2_t = mpl_graph::incidence_list_graph<graph_2_edges_t>;
 
-    using route_A_to_H = bfs_route_query_result_t<graph_2_t, A, H>;
-    static_assert(bfs_route_found_v<route_A_to_H>);
-    using route = bfs_route_path_t<route_A_to_H>;
-    static_assert(mpl::equal<route, mpl::vector<A,B,D,F,H>>::value);
-}
+//     using route_A_to_H = bfs_route_query_result_t<graph_2_t, A, H>;
+//     static_assert(bfs_route_found_v<route_A_to_H>);
+//     using route = bfs_route_path_t<route_A_to_H>;
+//     static_assert(mpl::equal<route, mpl::vector<A,B,D,F,H>>::value);
+// }

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -18,14 +18,23 @@
 
 
 // vertices
-struct A{}; 
-struct B{}; 
-struct C{}; 
-struct D{}; 
-struct E{}; 
-struct F{}; 
-struct G{};
-struct H{};
+// struct A{}; 
+// struct B{}; 
+// struct C{}; 
+// struct D{}; 
+// struct E{}; 
+// struct F{}; 
+// struct G{};
+// struct H{};
+#define VERTEX(name) struct name { using type = name; }
+VERTEX(A);
+VERTEX(B);
+VERTEX(C);
+VERTEX(D);
+VERTEX(E);
+VERTEX(F);
+VERTEX(G);
+VERTEX(H);
 
 // edges
 struct A_B{};
@@ -109,25 +118,39 @@ TEST(BFSRouteFinderTest, MplGraphSourceTarget) {
 }
 
 // // no route from A to G
-// TEST(BFSRouteFinderTest, NoRouteFromAToG) {
-//     using route_A_to_G = bfs_route_query_result_t<my_graph_type, A, G>;
-//     // Check that route was not found
-//     static_assert(!bfs_route_found_v<route_A_to_G>);
-// }
-
-// TEST(BFSRouteFinderTest, TestRouteFromAtoH) {
-//     using graph_edges_t = mpl::vector<
-//         EDGE(A,B),
-//         EDGE(B,D),
-//         EDGE(D,F)
-//     >;
-//     using graph_t = mpl_graph::incidence_list_graph<graph_edges_t>;
-
-//     using query_result_t = bfs_route_query_result_t<graph_t, A, F>;
+TEST(BFSRouteFinderTest, NoRouteFromAToG) {
+    using route_A_to_G = typename bfs_route_query_result_t<my_graph_type, A, G>::type;
     
-//     using mapping = bfs_parent_map_t<query_result_t>;
-//     static_assert(boost::is_same<typename mpl::at<mapping, A>::type, mpl::void_>::value);
-//     static_assert(boost::is_same<typename mpl::at<mapping, B>::type, A>::value);
-//     static_assert(boost::is_same<typename mpl::at<mapping, D>::type, B>::value);
-//     static_assert(boost::is_same<typename mpl::at<mapping, F>::type, D>::value);
-// }
+    using route_found_type = bfs_route_found_t<route_A_to_G>;
+    static constexpr bool found = bfs_route_found_v<route_A_to_G>;
+    static_assert(!found);
+
+    using route_type = bfs_route_path_t<route_A_to_G>;
+    static constexpr auto route_length = bfs_route_length_v<route_A_to_G>;
+
+    using parent_map_type = bfs_parent_map_t<route_A_to_G>;
+
+    // using parent_map = bfs_parent_map_t<route_A_to_G>;
+    // using route = bfs_route_path_t<route_A_to_G>;
+    // static constexpr auto route_size = bfs_route_length_v<route_A_to_G>;
+    // // Check that route was not found
+    // static_assert(!bfs_route_found_v<route_A_to_G>);
+}
+
+TEST(BFSRouteFinderTest, TestRouteFromAtoH) {
+    using graph_edges_t = mpl::vector<
+        EDGE(A,B),
+        EDGE(B,D),
+        EDGE(D,F)
+    >;
+    using graph_t = mpl_graph::incidence_list_graph<graph_edges_t>;
+    using query_result_t = bfs_route_query_result_t<graph_t, A, F>;
+
+    static_assert(bfs_route_found_v<query_result_t>, "Route from A to F should be found");
+    
+    // using mapping = bfs_parent_map_t<query_result_t>;
+    // static_assert(boost::is_same<typename mpl::at<mapping, A>::type, mpl::void_>::value);
+    // static_assert(boost::is_same<typename mpl::at<mapping, B>::type, A>::value);
+    // static_assert(boost::is_same<typename mpl::at<mapping, D>::type, B>::value);
+    // static_assert(boost::is_same<typename mpl::at<mapping, F>::type, D>::value);
+}

--- a/tests/test_boost_mpl_graph_shortest_path.cpp
+++ b/tests/test_boost_mpl_graph_shortest_path.cpp
@@ -23,14 +23,20 @@ struct D{};
 struct E{}; 
 struct F{}; 
 struct G{};
+struct H{};
 
 // edges
-struct A_B{}; 
+struct A_B{};
+struct A_C{};
 struct B_C{}; 
+struct B_D{};
+struct B_F{};
 struct C_D{}; 
 struct C_E{}; 
-struct C_F{}; 
-struct B_F{};
+struct C_F{};
+struct D_F{};
+struct F_H{};
+struct E_G{};
 
 // define the graph structure
 typedef mpl::vector<
@@ -41,8 +47,9 @@ typedef mpl::vector<
     mpl::vector<C_F, C, F>,
     mpl::vector<B_F, B, F>
 > my_graph_data_type;
-
 typedef mpl_graph::incidence_list_graph<my_graph_data_type> my_graph_type;
+
+#define EDGE(src,dst) mpl::vector<src##_##dst, src, dst>
 
 // Test that a route exists from A to F and is the shortest path A -> B -> F
 TEST(BFSRouteFinderTest, RouteFromAToFExists) {
@@ -56,7 +63,7 @@ TEST(BFSRouteFinderTest, RouteFromAToFExists) {
     static_assert(path_size == 3);
 
     // Check that the route is actually A -> B -> F
-    static constexpr bool path_correct = mpl::equal<bfs_route_path_t<route_A_to_F>, mpl::vector3<A,B,F>>::value;
+    static constexpr bool path_correct = mpl::equal<bfs_route_path_t<route_A_to_F>, mpl::vector<A,B,F>>::value;
     static_assert(path_correct);
 }
 
@@ -65,4 +72,22 @@ TEST(BFSRouteFinderTest, NoRouteFromAToG) {
     using route_A_to_G = bfs_route_query_result_t<my_graph_type, A, G>;
     // Check that route was not found
     static_assert(!bfs_route_found_v<route_A_to_G>);
+}
+
+TEST(BFSRouteFinderTest, Test2) {
+    using graph_2_edges_t = mpl::vector<
+        EDGE(A,B),
+        EDGE(B,D),
+        EDGE(D,F),
+        EDGE(F,H),
+        EDGE(A,C),
+        EDGE(C,E),
+        EDGE(E,G)
+    >;
+    using graph_2_t = mpl_graph::incidence_list_graph<graph_2_edges_t>;
+
+    using route_A_to_H = bfs_route_query_result_t<graph_2_t, A, H>;
+    static_assert(bfs_route_found_v<route_A_to_H>);
+    using route = bfs_route_path_t<route_A_to_H>;
+    static_assert(mpl::equal<route, mpl::vector<A,B,D,F,H>>::value);
 }


### PR DESCRIPTION
need to fix bfs implementation to use:
1. 'mpl::map<vertex, parent>' when examining search edges
2. recursive backtrack metafunction once target node is found to reconstruct the path