### PR TITLE
constexpr impl improvements

### DIFF
--- a/constexpr_graph_shortest_path.hpp
+++ b/constexpr_graph_shortest_path.hpp
@@ -128,3 +128,17 @@ bfs_find_shortest_path(const std::array<EdgeType, num_edges>& edges, NodeType<Ed
     result.found = true;
     return result;
 }
+
+// NTTP wrapper that returns an exact array of edges in the path
+template <const auto& Edges, size_t num_nodes, auto Start, auto Goal>
+consteval auto bfs_find_shortest_path() {
+    using Array = std::remove_cvref_t<decltype(Edges)>;
+    using EdgeType = typename Array::value_type;
+    constexpr size_t num_edges = std::tuple_size_v<Array>;
+    constexpr auto result = bfs_find_shortest_path<num_nodes, EdgeType, num_edges>(Edges, Start, Goal);
+    std::array<EdgeType, result.length> exact_path{};
+    for (size_t i = 0; i < result.length; ++i) {
+        exact_path[i] = result.path[i];
+    }
+    return exact_path;
+}

--- a/constexpr_graph_shortest_path.hpp
+++ b/constexpr_graph_shortest_path.hpp
@@ -12,10 +12,11 @@ concept EdgeConcept = requires(EdgeType e) {
     { e.dst };
     requires std::same_as<std::remove_cvref_t<decltype(e.src)>, std::remove_cvref_t<decltype(e.dst)>>;
     requires std::is_trivially_copyable_v<EdgeType>;
-
+    requires std::equality_comparable<EdgeType>;
 };
 
 template <typename EdgeType>
+requires EdgeConcept<EdgeType>
 using NodeType = std::remove_cvref_t<decltype(EdgeType::src)>;
 
 // ---------- constexpr queue ----------
@@ -62,40 +63,26 @@ struct BFSResult {
     constexpr auto view() const {
         return std::span(path.data(), length);
     }
+
+    // comparison operator for edge sequence (check for path equality)
+    template <size_t route_length>
+    constexpr bool is_equal(const std::array<EdgeType, route_length>& other) const {
+        static_assert(route_length <= max_edges, "Route length exceeds maximum edges");
+        if (length != route_length) return false;
+        for (size_t i = 0; i < length; ++i) {
+            if (path[i] != other[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
 };
-
-// ---------- comparison operator ----------
-template <typename EdgeType, size_t max_edges, size_t route_length>
-requires EdgeConcept<EdgeType>
-constexpr bool compare_routes(const BFSResult<EdgeType, max_edges>& a,
-                          const std::array<NodeType<EdgeType>, route_length>& b) {
-    if (a.length != route_length - 1) return false;
-    for (size_t i = 0; i < a.length; ++i) {
-        if (a.path[i].src != b[i] || a.path[i].dst != b[i + 1]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-template <typename EdgeType, size_t max_edges, size_t route_length>
-requires EdgeConcept<EdgeType>
-constexpr bool compare_routes(const BFSResult<EdgeType, max_edges>& a,
-                          const std::array<EdgeType, route_length>& b) {
-    if (a.length != route_length) return false;
-    for (size_t i = 0; i < a.length; ++i) {
-        if (a.path[i].src != b[i].src || a.path[i].dst != b[i].dst) {
-            return false;
-        }
-    }
-    return true;
-}
 
 // ---------- constexpr BFS ----------
 template <size_t num_nodes, typename EdgeType, size_t num_edges>
     requires EdgeConcept<EdgeType>
 constexpr BFSResult<EdgeType, num_nodes - 1>
-bfs_edges(const std::array<EdgeType, num_edges>& edges, NodeType<EdgeType> start, NodeType<EdgeType> goal) {
+bfs_find_shortest_path(const std::array<EdgeType, num_edges>& edges, NodeType<EdgeType> start, NodeType<EdgeType> goal) {
     auto [adj, counts] = adjacency_list<EdgeType, num_edges, num_nodes>(edges);
     std::array<int, num_nodes> prev{};
     std::array<int, num_nodes> via_edge{};
@@ -132,8 +119,10 @@ bfs_edges(const std::array<EdgeType, num_edges>& edges, NodeType<EdgeType> start
     // reconstruct path (edges)
     size_t len = 0;
     for (int at = goal; at != start; at = prev[at]) {
+        // copy edge
         result.path[len++] = edges[via_edge[at]];
     }
+
     std::reverse(result.path.begin(), result.path.begin() + len);
     result.length = len;
     result.found = true;

--- a/constexpr_graph_shortest_path.hpp
+++ b/constexpr_graph_shortest_path.hpp
@@ -6,43 +6,45 @@
 #include <concepts>
 #include <span>
 
-template <typename E>
-concept EdgeConcept = requires(E e) {
+template <typename EdgeType>
+concept EdgeConcept = requires(EdgeType e) {
     { e.src };
     { e.dst };
     requires std::same_as<std::remove_cvref_t<decltype(e.src)>, std::remove_cvref_t<decltype(e.dst)>>;
+    requires std::is_trivially_copyable_v<EdgeType>;
+
 };
 
-template <typename E>
-using NodeType = std::remove_cvref_t<decltype(E::src)>;
+template <typename EdgeType>
+using NodeType = std::remove_cvref_t<decltype(EdgeType::src)>;
 
 // ---------- constexpr queue ----------
-template <typename T, size_t Capacity>
+template <typename T, size_t capacity>
 struct ConstexprQueue {
-    std::array<T, Capacity> buf{};
+    std::array<T, capacity> buf{};
     size_t head = 0, tail = 0, sz = 0;
 
     constexpr bool empty() const { return sz == 0; }
     constexpr void push(const T& v) {
         buf[tail] = v;
-        tail = (tail + 1) % Capacity;
+        tail = (tail + 1) % capacity;
         ++sz;
     }
     constexpr T pop() {
         T v = buf[head];
-        head = (head + 1) % Capacity;
+        head = (head + 1) % capacity;
         --sz;
         return v;
     }
 };
 
 // ---------- adjacency builder ----------
-template <typename EdgeType, size_t NumEdges, size_t NodeCount>
+template <typename EdgeType, size_t num_edges, size_t node_count>
     requires EdgeConcept<EdgeType>
-constexpr auto adjacency_list(const std::array<EdgeType, NumEdges>& edges) {
-    std::array<std::array<size_t, NumEdges>, NodeCount> out{};
-    std::array<size_t, NodeCount> counts{};
-    for (size_t i = 0; i < NumEdges; ++i) {
+constexpr auto adjacency_list(const std::array<EdgeType, num_edges>& edges) {
+    std::array<std::array<size_t, num_edges>, node_count> out{};
+    std::array<size_t, node_count> counts{};
+    for (size_t i = 0; i < num_edges; ++i) {
         NodeType<EdgeType> u = edges[i].src;
         out[u][counts[u]++] = i;
     }
@@ -50,10 +52,10 @@ constexpr auto adjacency_list(const std::array<EdgeType, NumEdges>& edges) {
 }
 
 // ---------- result ----------
-template <typename EdgeType, size_t MaxEdges>
+template <typename EdgeType, size_t max_edges>
     requires EdgeConcept<EdgeType>
 struct BFSResult {
-    std::array<EdgeType, MaxEdges> path{};
+    std::array<EdgeType, max_edges> path{};
     size_t length = 0;
     bool found = false;
 
@@ -63,11 +65,11 @@ struct BFSResult {
 };
 
 // ---------- comparison operator ----------
-template <typename EdgeType, size_t MaxEdges, size_t RouteLength>
+template <typename EdgeType, size_t max_edges, size_t route_length>
 requires EdgeConcept<EdgeType>
-constexpr bool compare_routes(const BFSResult<EdgeType, MaxEdges>& a,
-                          const std::array<NodeType<EdgeType>, RouteLength>& b) {
-    if (a.length != RouteLength - 1) return false;
+constexpr bool compare_routes(const BFSResult<EdgeType, max_edges>& a,
+                          const std::array<NodeType<EdgeType>, route_length>& b) {
+    if (a.length != route_length - 1) return false;
     for (size_t i = 0; i < a.length; ++i) {
         if (a.path[i].src != b[i] || a.path[i].dst != b[i + 1]) {
             return false;
@@ -76,11 +78,11 @@ constexpr bool compare_routes(const BFSResult<EdgeType, MaxEdges>& a,
     return true;
 }
 
-template <typename EdgeType, size_t MaxEdges, size_t RouteLength>
+template <typename EdgeType, size_t max_edges, size_t route_length>
 requires EdgeConcept<EdgeType>
-constexpr bool compare_routes(const BFSResult<EdgeType, MaxEdges>& a,
-                          const std::array<EdgeType, RouteLength>& b) {
-    if (a.length != RouteLength) return false;
+constexpr bool compare_routes(const BFSResult<EdgeType, max_edges>& a,
+                          const std::array<EdgeType, route_length>& b) {
+    if (a.length != route_length) return false;
     for (size_t i = 0; i < a.length; ++i) {
         if (a.path[i].src != b[i].src || a.path[i].dst != b[i].dst) {
             return false;
@@ -90,22 +92,22 @@ constexpr bool compare_routes(const BFSResult<EdgeType, MaxEdges>& a,
 }
 
 // ---------- constexpr BFS ----------
-template <size_t NumNodes, typename EdgeType, size_t NumEdges>
+template <size_t num_nodes, typename EdgeType, size_t num_edges>
     requires EdgeConcept<EdgeType>
-constexpr BFSResult<EdgeType, NumNodes - 1>
-bfs_edges(const std::array<EdgeType, NumEdges>& edges, NodeType<EdgeType> start, NodeType<EdgeType> goal) {
-    auto [adj, counts] = adjacency_list<EdgeType, NumEdges, NumNodes>(edges);
-    std::array<int, NumNodes> prev{};
-    std::array<int, NumNodes> via_edge{};
-    std::array<bool, NumNodes> visited{};
+constexpr BFSResult<EdgeType, num_nodes - 1>
+bfs_edges(const std::array<EdgeType, num_edges>& edges, NodeType<EdgeType> start, NodeType<EdgeType> goal) {
+    auto [adj, counts] = adjacency_list<EdgeType, num_edges, num_nodes>(edges);
+    std::array<int, num_nodes> prev{};
+    std::array<int, num_nodes> via_edge{};
+    std::array<bool, num_nodes> visited{};
 
-    for (size_t i = 0; i < NumNodes; ++i) {
+    for (size_t i = 0; i < num_nodes; ++i) {
         prev[i] = -1;
         via_edge[i] = -1;
         visited[i] = false;
     }
 
-    ConstexprQueue<NodeType<EdgeType>, NumNodes> q{};
+    ConstexprQueue<NodeType<EdgeType>, num_nodes> q{};
     q.push(start);
     visited[start] = true;
 
@@ -124,7 +126,7 @@ bfs_edges(const std::array<EdgeType, NumEdges>& edges, NodeType<EdgeType> start,
         }
     }
 
-    BFSResult<EdgeType, NumNodes - 1> result{};
+    BFSResult<EdgeType, num_nodes - 1> result{};
     if (!visited[goal]) return result;
 
     // reconstruct path (edges)

--- a/constexpr_graph_shortest_path.hpp
+++ b/constexpr_graph_shortest_path.hpp
@@ -40,11 +40,11 @@ struct ConstexprQueue {
 };
 
 // ---------- adjacency builder ----------
-template <typename EdgeType, size_t num_edges, size_t node_count>
+template <typename EdgeType, size_t num_edges, size_t num_nodes>
     requires EdgeConcept<EdgeType>
 constexpr auto adjacency_list(const std::array<EdgeType, num_edges>& edges) {
-    std::array<std::array<size_t, num_edges>, node_count> out{};
-    std::array<size_t, node_count> counts{};
+    std::array<std::array<size_t, num_edges>, num_nodes> out{};
+    std::array<size_t, num_nodes> counts{};
     for (size_t i = 0; i < num_edges; ++i) {
         NodeType<EdgeType> u = edges[i].src;
         out[u][counts[u]++] = i;
@@ -64,18 +64,7 @@ struct BFSResult {
         return std::span(path.data(), length);
     }
 
-    // comparison operator for edge sequence (check for path equality)
-    template <size_t route_length>
-    constexpr bool is_equal(const std::array<EdgeType, route_length>& other) const {
-        static_assert(route_length <= max_edges, "Route length exceeds maximum edges");
-        if (length != route_length) return false;
-        for (size_t i = 0; i < length; ++i) {
-            if (path[i] != other[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
+
 };
 
 // ---------- constexpr BFS ----------
@@ -137,8 +126,6 @@ consteval auto bfs_find_shortest_path() {
     constexpr size_t num_edges = std::tuple_size_v<Array>;
     constexpr auto result = bfs_find_shortest_path<num_nodes, EdgeType, num_edges>(Edges, Start, Goal);
     std::array<EdgeType, result.length> exact_path{};
-    for (size_t i = 0; i < result.length; ++i) {
-        exact_path[i] = result.path[i];
-    }
+    std::ranges::copy(result.view(), exact_path.begin());
     return exact_path;
 }

--- a/constexpr_graph_shortest_path.hpp
+++ b/constexpr_graph_shortest_path.hpp
@@ -58,7 +58,6 @@ template <typename EdgeType, size_t max_edges>
 struct BFSResult {
     std::array<EdgeType, max_edges> path{};
     size_t length = 0;
-    bool found = false;
 
     constexpr auto view() const {
         return std::span(path.data(), length);
@@ -114,7 +113,6 @@ bfs_find_shortest_path(const std::array<EdgeType, num_edges>& edges, NodeType<Ed
 
     std::reverse(result.path.begin(), result.path.begin() + len);
     result.length = len;
-    result.found = true;
     return result;
 }
 

--- a/tests/test_constexpr_graph_shortest_path.cpp
+++ b/tests/test_constexpr_graph_shortest_path.cpp
@@ -8,6 +8,7 @@ static constexpr size_t NodeCount = G + 1;
 struct Edge {
     Node src;
     Node dst;
+    constexpr bool operator==(const Edge& other) const = default;
 };
 static_assert(EdgeConcept<Edge>);
 
@@ -23,18 +24,13 @@ constexpr std::array<Edge, 6> edges = {{
 // ---------- compile time test ----------
 
 TEST(ConstexprBFS, RouteAtoF) {
-    constexpr auto route_A_to_F = bfs_edges<NodeCount>(edges, A, F);
+    constexpr auto route_A_to_F = bfs_find_shortest_path<NodeCount>(edges, A, F);
     static_assert(route_A_to_F.found);
     static_assert(route_A_to_F.length == 2);
-    
-    // Test by vertex sequence
-    static_assert(compare_routes(route_A_to_F, std::array{A, B, F}));
-
-    // Test by edge sequence
-    static_assert(compare_routes(route_A_to_F, std::array<Edge, 2>{{{A, B}, {B, F}}}));
+    static_assert(route_A_to_F.is_equal(std::array<Edge, 2>{{{A, B}, {B, F}}}));
 }
 
 TEST(ConstexprBFS, NoRouteAtoG) {
-    constexpr auto route_A_to_G = bfs_edges<NodeCount>(edges, A, G);
+    constexpr auto route_A_to_G = bfs_find_shortest_path<NodeCount>(edges, A, G);
     static_assert(!route_A_to_G.found);
 }

--- a/tests/test_constexpr_graph_shortest_path.cpp
+++ b/tests/test_constexpr_graph_shortest_path.cpp
@@ -3,7 +3,7 @@
 #include "constexpr_graph_shortest_path.hpp"
 
 enum Node { A, B, C, D, E, F, G };
-static constexpr size_t NodeCount = G + 1;
+static constexpr size_t node_count = G + 1;
 
 struct Edge {
     Node src;
@@ -24,13 +24,15 @@ constexpr std::array<Edge, 6> edges = {{
 // ---------- compile time test ----------
 
 TEST(ConstexprBFS, RouteAtoF) {
-    constexpr auto route_A_to_F = bfs_find_shortest_path<NodeCount>(edges, A, F);
-    static_assert(route_A_to_F.found);
-    static_assert(route_A_to_F.length == 2);
-    static_assert(route_A_to_F.is_equal(std::array<Edge, 2>{{{A, B}, {B, F}}}));
+    constexpr auto route_A_to_F = bfs_find_shortest_path<edges, node_count, A, F>();
+    static_assert(std::is_same_v<decltype(route_A_to_F), const std::array<Edge, 2>>);
+    static_assert(route_A_to_F.size() == 2);
+    static_assert(route_A_to_F[0] == Edge{A, B});
+    static_assert(route_A_to_F[1] == Edge{B, F});
 }
 
 TEST(ConstexprBFS, NoRouteAtoG) {
-    constexpr auto route_A_to_G = bfs_find_shortest_path<NodeCount>(edges, A, G);
-    static_assert(!route_A_to_G.found);
+    constexpr auto route_A_to_G = bfs_find_shortest_path<edges, node_count, A, G>();
+    static_assert(std::is_same_v<decltype(route_A_to_G), const std::array<Edge, 0>>);
+    static_assert(route_A_to_G.size() == 0);
 }


### PR DESCRIPTION
- `constexpr` API uses NTTP edge list to get a correctly sized std::array at call site.
- `EdgeConcept` correctly requires trivially copyable edge types.
- cleanups